### PR TITLE
Bugfix for Windows (std::mem usage)

### DIFF
--- a/src/stack.rs
+++ b/src/stack.rs
@@ -12,6 +12,7 @@ use std::ptr;
 use std::sync::atomic;
 use std::env;
 use std::fmt;
+use std::mem;
 
 use libc;
 


### PR DESCRIPTION
Bug with function in stack.rs:

``` rust
#[cfg(windows)]
fn page_size() -> usize {
    unsafe {
        let mut info = mem::zeroed();
        libc::GetSystemInfo(&mut info);
        info.dwPageSize as usize
    }
}
```
