### PR TITLE
Update memmap dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,6 @@ gcc = "^0.3.12"
 log = "^0.3.1"
 
 [dependencies]
-memmap = "^0.1.0"
+memmap = "^0.2"
 libc = "^0.1.10"
 log = "^0.3.1"

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -42,16 +42,7 @@ impl Stack {
         // allocation failure, which would fail to spawn the task. But there's
         // not many sensible things to do on OOM.  Failure seems fine (and is
         // what the old stack allocation did).
-
-        let options =
-            if cfg!(all(not(windows), not(target_os = "freebsd"), not(target_os = "dragonfly"))) {
-                MmapOptions { stack: true }
-            } else if cfg!(any(target_os = "freebsd", target_os = "dragonfly")) {
-                MmapOptions { stack: false }
-            } else {
-                MmapOptions { stack: false }
-            };
-
+        let options = MmapOptions { stack: true };
         let stack = match Mmap::anonymous_with_options(size, Protection::ReadCopy, options) {
             Ok(map) => map,
             Err(e) => panic!("mmap for stack of size {} failed: {}", size, e)


### PR DESCRIPTION
This also removes the conditionals around setting the MAP_STACK flag when
creating the mmap. The memmap crate already ignores the flag on Windows.
The remaining two exceptions,
[FreeBSD](https://www.freebsd.org/cgi/man.cgi?sektion=2&query=mmap) and
[DragonflyBSD](https://www.dragonflybsd.org/cgi/web-man?command=mmap&section=2)
both claim to support MAP_STACK, at least in the man pages. I don't have a
system of either flavor to actually try out, though.
