### PR TITLE
Force move the Context when context switch

### DIFF
--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -28,12 +28,7 @@ fn main() {
     let stack = ProtectedFixedSizeStack::default();
 
     // Allocate a Context on the stack.
-    // `t` will now contain a reference to the context function
-    // `context_function()` and a `data` value of 0.
-    let mut t = Transfer {
-        context: Context::new(&stack, context_function),
-        data: 0,
-    };
+    let mut t = Transfer::new(Context::new(&stack, context_function), 0);
 
     // Yield 10 times to `context_function()`.
     for _ in 0..10 {
@@ -43,8 +38,6 @@ fn main() {
         print!("Resuming => ");
         t = t.context.resume(0);
 
-        // `t` will now contain a reference to the `Context` which `resumed()` us
-        // (here: `context_function()`) and the value passed to it.
         println!("Got {}", t.data);
     }
 

--- a/examples/fibonacci.rs
+++ b/examples/fibonacci.rs
@@ -33,12 +33,7 @@ fn main() {
     let stack = ProtectedFixedSizeStack::default();
 
     // Allocate a Context on the stack.
-    // `t` will now contain a reference to the context function
-    // `context_function()` and a `data` value of 0.
-    let mut t = Transfer {
-        context: Context::new(&stack, context_function),
-        data: 0,
-    };
+    let mut t = Transfer::new(Context::new(&stack, context_function), 0);
 
     // Yield 10 times to `context_function()`.
     for _ in 0..10 {
@@ -48,8 +43,6 @@ fn main() {
         print!("Resuming => ");
         t = t.context.resume(0);
 
-        // `t` will now contain a reference to the `Context` which `resumed()` us
-        // (here: `context_function()`) and the value passed to it.
         println!("Got {}", t.data);
     }
 


### PR DESCRIPTION
In `1.0` implementation, you must reset the `&Context` after calling
1. `resume`
2. `resume_ontop`

so it would be better to make use of Rust's ownership system to restrict this behavior.

Basic idea is:
- You can only call the functions that mentions above on a `Context` with `self` as receiver.
- `Transfer` becomes a tuple struct to provide convenience to get the `Context` out by pattern match.
  
  ``` rust
  let Transfer(context, data) = context.resume(0);
  ```
- Disable `Copy` and `Clone` for `Transfer`.

Request for comments.
