### PR TITLE
Various improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: rust
 rust:
   - nightly
-  - 1.9.0
+  - stable
 
 os:
   - linux

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ kernel32-sys = "0.2"
 winapi = "0.2"
 
 [build-dependencies]
-gcc = "0.3"
+cc = "~1"
 
 [features]
 nightly = []

--- a/benches/context.rs
+++ b/benches/context.rs
@@ -34,12 +34,12 @@ fn resume_reference_perf(b: &mut Bencher) {
 fn resume(b: &mut Bencher) {
     extern "C" fn yielder(mut t: Transfer) -> ! {
         loop {
-            t = t.context.resume(1);
+            t = unsafe { t.context.resume(1) };
         }
     }
 
     let stack = FixedSizeStack::default();
-    let mut t = Transfer::new(Context::new(&stack, yielder), 0);
+    let mut t = Transfer::new(unsafe { Context::new(&stack, yielder) }, 0);
 
     b.iter(|| unsafe {
         t = mem::transmute_copy::<_, Transfer>(&t).context.resume(0);
@@ -50,7 +50,7 @@ fn resume(b: &mut Bencher) {
 fn resume_ontop(b: &mut Bencher) {
     extern "C" fn yielder(mut t: Transfer) -> ! {
         loop {
-            t = t.context.resume(1);
+            t = unsafe { t.context.resume(1) };
         }
     }
 
@@ -59,7 +59,7 @@ fn resume_ontop(b: &mut Bencher) {
     }
 
     let stack = FixedSizeStack::default();
-    let mut t = Transfer::new(Context::new(&stack, yielder), 0);
+    let mut t = Transfer::new(unsafe { Context::new(&stack, yielder) }, 0);
 
     b.iter(|| unsafe {
         t = mem::transmute_copy::<_, Transfer>(&t).context.resume_ontop(0, ontop_function);

--- a/build.rs
+++ b/build.rs
@@ -5,7 +5,7 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
-extern crate gcc;
+extern crate cc;
 
 use std::path::PathBuf;
 use std::env;
@@ -65,7 +65,7 @@ fn main() {
 
     let prefixes = ["jump", "make", "ontop"];
     let base_path: PathBuf = ["src", "asm"].iter().collect();
-    let mut config = gcc::Config::new();
+    let mut config = cc::Build::new();
 
     config.define("BOOST_CONTEXT_EXPORT", None);
 

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -5,6 +5,8 @@
 // http://opensource.org/licenses/MIT>, at your option. This file may not be
 // copied, modified, or distributed except according to those terms.
 
+use std::error::Error;
+use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::io;
 use std::ops::Deref;
 use std::os::raw::c_void;
@@ -19,6 +21,32 @@ pub enum StackError {
 
     /// Returned if some kind of I/O error happens during allocation.
     IoError(io::Error),
+}
+
+impl Display for StackError {
+    fn fmt(&self, fmt: &mut Formatter) -> FmtResult {
+        match *self {
+            StackError::ExceedsMaximumSize(size) => {
+                write!(fmt, "Requested more than max size of {} bytes for a stack", size)
+            },
+            StackError::IoError(ref e) => e.fmt(fmt),
+        }
+    }
+}
+
+impl Error for StackError {
+    fn description(&self) -> &str {
+        match *self {
+            StackError::ExceedsMaximumSize(_) => "exceeds maximum stack size",
+            StackError::IoError(ref e) => e.description(),
+        }
+    }
+    fn cause(&self) -> Option<&Error> {
+        match *self {
+            StackError::ExceedsMaximumSize(_) => None,
+            StackError::IoError(ref e) => Some(e),
+        }
+    }
 }
 
 /// Represents any kind of stack memory.


### PR DESCRIPTION
Hello

I noticed the `StackError` doesn't implement the `std::error::Error` trait, which is expected by several libraries. This adds the implementation.

I also noticed some other little things on the way, so they are included. It's part of a single branch, even when these are discrete unrelated commits ‒ it looked easier to create just one pull request, but if you prefer, I can split it up.