### PR TITLE
Upgraded deprecated version of 'winapi'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "context"
-version = "2.1.0"
+version = "3.0.0"
 authors = ["Y. T. Chung <zonyitoo@gmail.com>", "Leonard Hecker <leonard@hecker.io>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/zonyitoo/context-rs"
@@ -25,8 +25,7 @@ exclude = [
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-kernel32-sys = "0.2"
-winapi = "0.2"
+winapi = { version = "0.3", features = ["minwindef", "winnt", "memoryapi", "sysinfoapi"] }
 
 [build-dependencies]
 cc = "~1"

--- a/benches/context.rs
+++ b/benches/context.rs
@@ -12,8 +12,8 @@ extern crate test;
 
 use test::Bencher;
 
-use context::{Context, Transfer};
 use context::stack::FixedSizeStack;
+use context::{Context, Transfer};
 use std::mem;
 
 #[bench]
@@ -23,7 +23,7 @@ fn resume_reference_perf(b: &mut Bencher) {
         test::black_box(t)
     }
 
-    let mut t: Transfer = unsafe { mem::uninitialized() };
+    let mut t: Transfer = unsafe { mem::MaybeUninit::uninit().assume_init() };
 
     b.iter(|| unsafe {
         t = yielder(mem::transmute_copy::<_, Transfer>(&t));
@@ -62,6 +62,8 @@ fn resume_ontop(b: &mut Bencher) {
     let mut t = Transfer::new(unsafe { Context::new(&stack, yielder) }, 0);
 
     b.iter(|| unsafe {
-        t = mem::transmute_copy::<_, Transfer>(&t).context.resume_ontop(0, ontop_function);
+        t = mem::transmute_copy::<_, Transfer>(&t)
+            .context
+            .resume_ontop(0, ontop_function);
     });
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -6,8 +6,8 @@
 // copied, modified, or distributed except according to those terms.
 
 use std::fmt;
-use std::os::raw::c_void;
 
+use c_void;
 use stack::Stack;
 
 // Requires cdecl calling convention on x86, which is the default for "C" blocks.
@@ -18,7 +18,6 @@ extern "C" {
     /// * `sp`   - A pointer to the bottom of the stack.
     /// * `size` - The size of the stack.
     /// * `f`    - A function to be invoked on the first call to jump_fcontext(this, _).
-    #[inline(never)]
     fn make_fcontext(sp: *mut c_void, size: usize, f: ContextFn) -> &'static c_void;
 
     /// Yields the execution to another `Context`.
@@ -27,7 +26,6 @@ extern "C" {
     /// * `to` - A pointer to the `Context` with whom we swap execution.
     /// * `p`  - An arbitrary argument that will be set as the `data` field
     ///          of the `Transfer` object passed to the other Context.
-    #[inline(never)]
     fn jump_fcontext(to: &'static c_void, p: usize) -> Transfer;
 
     /// Yields the execution to another `Context` and executes a function "ontop" of it's stack.
@@ -37,7 +35,6 @@ extern "C" {
     /// * `p`  - An arbitrary argument that will be set as the `data` field
     ///          of the `Transfer` object passed to the other Context.
     /// * `f`  - A function to be invoked on `to` before returning.
-    #[inline(never)]
     fn ontop_fcontext(to: &'static c_void, p: usize, f: ResumeOntopFn) -> Transfer;
 }
 
@@ -152,10 +149,10 @@ impl Transfer {
 #[cfg(test)]
 mod tests {
     use std::mem;
-    use std::os::raw::c_void;
 
-    use stack::ProtectedFixedSizeStack;
     use super::*;
+    use c_void;
+    use stack::ProtectedFixedSizeStack;
 
     #[test]
     fn type_sizes() {
@@ -168,7 +165,24 @@ mod tests {
     fn stack_alignment() {
         #[allow(non_camel_case_types)]
         #[repr(simd)]
-        struct u8x16(u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8, u8);
+        struct u8x16(
+            u8,
+            u8,
+            u8,
+            u8,
+            u8,
+            u8,
+            u8,
+            u8,
+            u8,
+            u8,
+            u8,
+            u8,
+            u8,
+            u8,
+            u8,
+            u8,
+        );
 
         extern "C" fn context_function(t: Transfer) -> ! {
             // If we do not use an array in combination with mem::uninitialized(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,6 @@
 
 extern crate libc;
 #[cfg(windows)]
-extern crate kernel32;
-#[cfg(windows)]
 extern crate winapi;
 
 /// Provides the `Context` and `Transfer` types for
@@ -29,4 +27,9 @@ pub mod stack;
 
 mod sys;
 
-pub use context::{Context, Transfer, ContextFn, ResumeOntopFn};
+pub use context::{Context, ContextFn, ResumeOntopFn, Transfer};
+
+#[cfg(not(target_os = "windows"))]
+pub use std::os::raw::c_void;
+#[cfg(target_os = "windows")]
+pub use winapi::ctypes::c_void;

--- a/src/stack.rs
+++ b/src/stack.rs
@@ -9,8 +9,8 @@ use std::error::Error;
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::io;
 use std::ops::Deref;
-use std::os::raw::c_void;
 
+use c_void;
 use sys;
 
 /// Error type returned by stack allocation methods.
@@ -27,21 +27,26 @@ impl Display for StackError {
     fn fmt(&self, fmt: &mut Formatter) -> FmtResult {
         match *self {
             StackError::ExceedsMaximumSize(size) => {
-                write!(fmt, "Requested more than max size of {} bytes for a stack", size)
-            },
+                write!(
+                    fmt,
+                    "Requested more than max size of {} bytes for a stack",
+                    size
+                )
+            }
             StackError::IoError(ref e) => e.fmt(fmt),
         }
     }
 }
 
 impl Error for StackError {
+    #[allow(deprecated, deprecated_in_future)]
     fn description(&self) -> &str {
         match *self {
             StackError::ExceedsMaximumSize(_) => "exceeds maximum stack size",
             StackError::IoError(ref e) => e.description(),
         }
     }
-    fn cause(&self) -> Option<&Error> {
+    fn cause(&self) -> Option<&dyn Error> {
         match *self {
             StackError::ExceedsMaximumSize(_) => None,
             StackError::IoError(ref e) => Some(e),


### PR DESCRIPTION
This is to fix the following Rust warning: `the following packages contain code that will be rejected by a future version of Rust: winapi v0.2.8`