### PR TITLE
Avoid UB due to uninitialized memory in `max_stack_size`

### DIFF
--- a/src/sys/unix/mod.rs
+++ b/src/sys/unix/mod.rs
@@ -98,13 +98,9 @@ pub fn max_stack_size() -> usize {
     let mut ret = PAGE_SIZE.load(Ordering::Relaxed);
 
     if ret == 0 {
-        let mut limit;
-        let limitret;
-
-        unsafe {
-            limit = mem::MaybeUninit::uninit().assume_init();
-            limitret = libc::getrlimit(libc::RLIMIT_STACK, &mut limit);
-        }
+        let mut limit = mem::MaybeUninit::uninit();
+        let limitret = unsafe { libc::getrlimit(libc::RLIMIT_STACK, limit.as_mut_ptr()) };
+        let limit = unsafe { limit.assume_init() };
 
         if limitret == 0 {
             ret = if limit.rlim_max == libc::RLIM_INFINITY


### PR DESCRIPTION
`mem::MaybeUninit::uninit().assume_init()` is almost always UB.
(Caught by Miri)