### PR TITLE
Fix ARM64 builds on Windows

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -57,7 +57,7 @@ fn main() {
     };
 
     let (asm, ext) = if is_win_msvc {
-        if arch == "arm" {
+        if matches!(arch, "arm" | "arm64") {
             ("armasm", "asm")
         } else {
             ("masm", "asm")

--- a/src/asm/ontop_arm64_aapcs_pe_armasm.asm
+++ b/src/asm/ontop_arm64_aapcs_pe_armasm.asm
@@ -60,7 +60,7 @@
     AREA |.text|, CODE, READONLY, ALIGN=4, CODEALIGN
     EXPORT ontop_fcontext
 
-ontop_fcontext proc BOOST_CONTEXT_EXPORT
+ontop_fcontext proc
     ; prepare stack for GP + FPU
     sub  sp, sp, #0xd0
 


### PR DESCRIPTION
- `arm` and `arm64` are defined separately in the build script, but the `armasm` suffix is only used for `arm`
- The `BOOST_CONTEXT_EXPORT` macro after `ontop_fcontext proc` causes armasm to throw an error, and is not consistent with the other armasm files